### PR TITLE
Fix issue with Composer

### DIFF
--- a/src/ComposerCost.php
+++ b/src/ComposerCost.php
@@ -14,6 +14,10 @@ class ComposerCost implements PluginInterface, EventSubscriberInterface
     protected $io;
     protected $composer;
 
+     public function uninstall(Composer $composer, IOInterface $io)
+    {
+    }
+    
     /**
      * {@inheritdoc}
      */

--- a/src/ComposerCost.php
+++ b/src/ComposerCost.php
@@ -14,9 +14,17 @@ class ComposerCost implements PluginInterface, EventSubscriberInterface
     protected $io;
     protected $composer;
 
-     public function uninstall(Composer $composer, IOInterface $io)
-    {
-    }
+    /**
+     * {@inheritdoc}
+     */
+    public function uninstall(Composer $composer, IOInterface $io)
+    {}
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function deactivate(Composer $composer, IOInterface $io)
+    {}
     
     /**
      * {@inheritdoc}


### PR DESCRIPTION
Add implement method uninstall and deactivate.

Fatal Error generated with PHP 7.4 and composer 2.0.11

PHP Fatal error:  Class ComposerCost\ComposerCost contains 2 abstract methods and must therefore be declared abstract or implement the remaining methods (Composer\Plugin\PluginInterface::deactivate, Composer\Plugin\PluginInterface::uninstall) in /composer-cost/src/ComposerCost.php on line 12

Fatal error: Class ComposerCost\ComposerCost contains 2 abstract methods and must therefore be declared abstract or implement the remaining methods (Composer\Plugin\PluginInterface::deactivate, Composer\Plugin\PluginInterface::uninstall) in /sarfraznawaz2005/composer-cost/src/ComposerCost.php on line 12